### PR TITLE
test(server): disable plugin timeouts

### DIFF
--- a/src/server.test.js
+++ b/src/server.test.js
@@ -306,7 +306,7 @@ describe("Server deployment", () => {
 					Object.assign(process.env, envVariables);
 					config = await getConfig();
 
-					server = Fastify();
+					server = Fastify({ pluginTimeout: 0 });
 					await server.register(startServer, config).ready();
 				});
 
@@ -478,7 +478,7 @@ describe("Server deployment", () => {
 				Object.assign(process.env, envVariables);
 				config = await getConfig();
 
-				server = Fastify();
+				server = Fastify({ pluginTimeout: 0 });
 				await server.register(startServer, config).ready();
 			});
 
@@ -659,7 +659,7 @@ describe("Server deployment", () => {
 
 			// Turn off logging for test runs
 			config.fastifyInit.logger = undefined;
-			server = Fastify(config.fastifyInit);
+			server = Fastify({ ...config.fastifyInit, pluginTimeout: 0 });
 			await server.register(startServer, config).listen(config.fastify);
 		});
 
@@ -748,7 +748,7 @@ describe("Server deployment", () => {
 			});
 			config = await getConfig();
 
-			server = Fastify();
+			server = Fastify({ pluginTimeout: 0 });
 			await server.register(startServer, config).ready();
 		});
 
@@ -818,7 +818,7 @@ describe("Server deployment", () => {
 			});
 			config = await getConfig();
 
-			server = Fastify({ pluginTimeout: 30000 });
+			server = Fastify({ pluginTimeout: 0 });
 			await server.register(startServer, config);
 
 			server.get("/error", async () => {


### PR DESCRIPTION
Plugin load time impacted by test runner resource constraints